### PR TITLE
Running DreamerV3 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Install [JAX][jax] and then the other dependencies:
 pip install -r requirements.txt
 ```
 
+For Windows use this command:
+```sh
+pip install -r requirements.txt -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
+```
+
 Simple training script:
 
 ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ crafter
 gym==0.19.0
 jax==0.3.25
 jaxlib==0.3.25
-numpy
+numpy==1.23.5
 optax
 rich
 ruamel.yaml


### PR DESCRIPTION
I pinned the numpy version to 1.23.5 and added a description how to install it on windows. 