### PR TITLE
remove duplicated call to exploration behavior policy

### DIFF
--- a/dreamerv3/agent.py
+++ b/dreamerv3/agent.py
@@ -55,7 +55,6 @@ class Agent(nj.Module):
     embed = self.wm.encoder(obs)
     latent, _ = self.wm.rssm.obs_step(
         prev_latent, prev_action, embed, obs['is_first'])
-    self.expl_behavior.policy(latent, expl_state)
     task_outs, task_state = self.task_behavior.policy(latent, task_state)
     expl_outs, expl_state = self.expl_behavior.policy(latent, expl_state)
     if mode == 'eval':


### PR DESCRIPTION
Feel free to ignore/delete the PR if the extra call to `self.expl_behavior.policy(latent, expl_state)` is here on purpose.
I tested with and without and I didn't see any difference, but felt not optimal to have this extra call.