### PR TITLE
Fix TF-Probability module name for Normal distribution latent

### DIFF
--- a/dreamerv3/nets.py
+++ b/dreamerv3/nets.py
@@ -78,7 +78,7 @@ class RSSM(nj.Module):
     else:
       mean = state['mean'].astype(f32)
       std = state['std'].astype(f32)
-      return tfp.MultivariateNormalDiag(mean, std)
+      return tfd.MultivariateNormalDiag(mean, std)
 
   def obs_step(self, prev_state, prev_action, embed, is_first):
     is_first = cast(is_first)


### PR DESCRIPTION
Currently Normal distribution latent mode does not work due to a typo in the use of imported module (should be `tfd` instead of `tfp`). This can be quickly checked by:
```
python dreamerv3/train.py --logdir ~/logdir/$(date "+%Y%m%d-%H%M%S") --configs dmc_vision --rssm.classes 0
```

This PR fixes that.