### PR TITLE
Downgrade ale_py to 0.8.1 in Dockerfile

### DIFF
--- a/dreamerv3/Dockerfile
+++ b/dreamerv3/Dockerfile
@@ -45,7 +45,7 @@ COPY embodied/scripts/install-minecraft.sh .
 RUN sh install-minecraft.sh
 COPY embodied/scripts/install-dmlab.sh .
 RUN sh install-dmlab.sh
-RUN pip install ale_py autorom[accept-rom-license]
+RUN pip install ale_py==0.8.1 autorom[accept-rom-license]
 RUN pip install procgen_mirror
 RUN pip install crafter
 RUN pip install dm_control


### PR DESCRIPTION
The latest update of ale_py 0.9.0 removed rom utils which causes Dockerfile installation errors. See #134 

Downgrading ale_py to 0.8.1 fixes this error