### PR TITLE
More compatible syntax in selectors.py

### DIFF
--- a/embodied/replay/selectors.py
+++ b/embodied/replay/selectors.py
@@ -85,8 +85,11 @@ class Recency:
   def _sample(self, tree, rng, bfactor=16):
     path = []
     for level, prob in enumerate(tree):
-      segment = prob[*path]
-      path += (rng.choice(len(segment), p=segment),)
+        segment = prob
+        for p in path:
+            segment = segment[p]
+        index = rng.choice(len(segment), p=segment)
+        path.append(index)
     index = sum(
         index * bfactor ** (len(tree) - level - 1)
         for level, index in enumerate(path))


### PR DESCRIPTION
Solution to execution's error on linux ubuntu 22 (on a venv with python 3.10.12):

File "/home/user/dreamerv3/dreamerv3/main.py", line 18, in <module>
    import embodied
  File "/home/user/dreamerv3/embodied/__init__.py", line 7, in <module>
    from . import replay
  File "/home/user/dreamerv3/embodied/replay/__init__.py", line 1, in <module>
    from .replay import Replay
  File "/home/user/dreamerv3/embodied/replay/replay.py", line 12, in <module>
    from . import selectors
  File "/home/user/dreamerv3/embodied/replay/selectors.py", line 88
    segment = prob[*path]
                   ^
SyntaxError: invalid syntax

The syntax is simpler and should work with all versions.