### PR TITLE
Add missing __len__ impl to Mixture selector

### DIFF
--- a/embodied/core/selectors.py
+++ b/embodied/core/selectors.py
@@ -211,6 +211,9 @@ class Mixture:
     self.fractions = np.array([fractions[key] for key in keys], np.float32)
     self.rng = np.random.default_rng(seed)
 
+  def __len__(self):
+    return len(self.selectors[0])
+
   def __call__(self):
     return self.rng.choice(self.selectors, p=self.fractions)()
 


### PR DESCRIPTION
First off, **thanks for the great work**!

### Issue Description

Sampling with the [`Mixture`](https://github.com/danijar/dreamerv3/blob/55c8c67c956fbdace4bf8b594ea12e934a3ae4ba/embodied/core/selectors.py#L200) selector results in an error due to missing `__len__()` implementation.

```log
Traceback (most recent call last):
  ...
  File "dreamerv3/embodied/core/replay.py", line 123, in <lambda>
    limiters.wait(lambda: len(self.sampler), message)
TypeError: object of type 'Mixture' has no len()
```

https://github.com/danijar/dreamerv3/blob/55c8c67c956fbdace4bf8b594ea12e934a3ae4ba/embodied/core/replay.py#L123

### PR Considerations

The implemented `__len__()` simply dispatches the call to the first selector. Reasoning:

- At least one `selector` is guaranteed to exist after `Mixture.__init__()`:

https://github.com/danijar/dreamerv3/blob/55c8c67c956fbdace4bf8b594ea12e934a3ae4ba/embodied/core/selectors.py#L202-L210

- The output of `len()` for each `selector` is identical because they have the same items:

https://github.com/danijar/dreamerv3/blob/55c8c67c956fbdace4bf8b594ea12e934a3ae4ba/embodied/core/selectors.py#L217-L223