### PR TITLE
Fix README paper link + ignore .DS_Store files (Closes #191)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.egg-info
 MUJOCO_LOG.TXT
 ;
+*.DS_STORE

--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ implementation has been tested to reproduce the official results on a range of
 environments.
 
 [jax]: https://github.com/google/jax#pip-installation-gpu-cuda
-[paper]: https://arxiv.org/pdf/2301.04104v1.pdf
+[paper]: https://arxiv.org/abs/2301.04104
 [website]: https://danijar.com/dreamerv3
 [tweet]: https://twitter.com/danijarh/status/1613161946223677441


### PR DESCRIPTION
### Summary
This PR makes two minor but important fixes:

1) README Fix
Replaces the outdated direct PDF link to the DreamerV3 paper with a link to the arXiv landing page (https://arxiv.org/abs/2301.04104).

The previously linked PDF pointed to an earlier version of the paper.
That version used a different set of hyperparameters which radically changes the implementation and may mislead users.
Linking to the arXiv abstract page ensures readers always see the latest version.

2) .gitignore Update
Adds .DS_Store to .gitignore to avoid polluting the repo with macOS metadata files.

### Changes
README.md:
    Old: https://arxiv.org/pdf/2301.04104.pdf
    New: https://arxiv.org/abs/2301.04104

.gitignore:
    Added .DS_Store

### Rationale
This improves usability and avoids confusion, especially for those attempting to replicate or build on DreamerV3. Also a small quality-of-life fix for devs on macOS.

Closes #191