### PR TITLE
Fix typo in Agent.report metric aggregation

### DIFF
--- a/dreamerv3/agent.py
+++ b/dreamerv3/agent.py
@@ -257,7 +257,7 @@ class Agent(embodied.jax.Agent):
     # Train metrics
     _, (new_carry, entries, outs, mets) = self.loss(
         carry, obs, prevact, training=False)
-    mets.update(mets)
+    metrics.update(mets)
 
     # Grad norms
     if self.config.report_gradnorms:


### PR DESCRIPTION
Reporting metrics were incomplete because Agent.report() performed a no-op
update (mets.update(mets)) instead of adding the metrics from loss() into the
report output.