### PR TITLE
Fix Atari frame maxpooling on reset

### DIFF
--- a/embodied/envs/atari.py
+++ b/embodied/envs/atari.py
@@ -144,7 +144,7 @@ class Atari(embodied.Env):
     self._render()
     for i, dst in enumerate(self.buffers):
       if i > 0:
-        np.copyto(self.buffers[0], dst)
+        np.copyto(dst, self.buffers[0])
 
   def _render(self, reset=False):
     self.buffers.appendleft(self.buffers.pop())


### PR DESCRIPTION
While I was playing around with the Atari environment I found this little issue when resetting the buffer.

I _think_ the intended behavior is to replace everything in the buffer with the first observation.

However, when the pooling parameter (buffer size) was > 1 then the first element is iteratively overwritten with the other Elements in the buffer (which are initially arrays with only zeros) and therefore the first observation is always a black image.

The error _seems_ to be putting the self.buffers[0] and dst parameters for the np.copyto() method in the wrong order.
According to the numpy documentation the first parameter should be the destination and the second one the source: https://numpy.org/doc/stable/reference/generated/numpy.copyto.html

The implemented switch in this commit _should_ fix this.
I tested it by adding this little testing script to the main.py file and observed that now the first observation is actually an image from the environment and not a black image:

```
elif config.script == 'test':

      import matplotlib.pyplot as plt
      env = make_env(config, 0)

      action = {"action": np.int32(0),
                "reset": False,
      }
      for _ in range(4):
        obs = env.step(action)
        plt.imshow(obs["image"], cmap="gray")
        plt.show()
```

I have not tested yet if that change influences any model behavior in the environment.

Hope to hear from you about, if that is helpful.

Cheers,
Anton